### PR TITLE
feat: Integrate sqlite-vec for local vector storage

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1293,6 +1293,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastembed"
 version = "4.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +1938,18 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -2628,6 +2652,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4246,6 +4281,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4792,6 +4852,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite-vec"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec77b84fb8dd5f0f8def127226db83b5d1152c5bf367f09af03998b76ba554a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5276,13 +5357,17 @@ version = "0.1.0"
 dependencies = [
  "fastembed",
  "notify",
+ "rusqlite",
  "serde",
  "serde_json",
+ "sqlite-vec",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
+ "zerocopy",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,10 @@ tokio = { version = "1", features = ["full"] }
 fastembed = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rusqlite = { version = "0.38.0", features = ["bundled"] }
+sqlite-vec = "0.1.6"
+zerocopy = "0.8.42"
+thiserror = "2.0.18"
 
 [dev-dependencies]
 tempfile = "3.26.0"

--- a/src-tauri/src/core/db.rs
+++ b/src-tauri/src/core/db.rs
@@ -1,0 +1,103 @@
+use rusqlite::{params, Connection, Result as SqliteResult};
+use sqlite_vec::sqlite3_vec_init;
+use std::path::{Path, PathBuf};
+use zerocopy::IntoBytes;
+
+
+pub fn init_db(vault_path: &Path) -> SqliteResult<Connection> {
+    let db_path = vault_path.join(".cerebro.db");
+    let db = Connection::open(&db_path)?;
+    db.execute_batch("PRAGMA journal_mode = WAL;")?;
+    unsafe {
+        sqlite3_vec_init(db.handle());
+    }
+    db.execute_batch(
+        "
+        BEGIN;
+        CREATE TABLE IF NOT EXISTS docs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            path TEXT UNIQUE
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS vec_docs USING vec0(
+            embedding float[384]
+        );
+        COMMIT;
+        "
+    )?;
+    Ok(db)
+}
+
+pub fn upsert_embedding(conn: &Connection, path: &Path, embedding: &[f32]) -> SqliteResult<()> {
+    let path_str = path.to_string_lossy().to_string();
+    conn.execute(
+        "INSERT OR IGNORE INTO docs (path) VALUES (?1)",
+        params![&path_str],
+    )?;
+    let id: i64 = conn.query_row(
+        "SELECT id FROM docs WHERE path = ?1",
+        params![&path_str],
+        |row| row.get(0),
+    )?;
+    conn.execute(
+        "INSERT OR REPLACE INTO vec_docs (rowid, embedding) VALUES (?1, ?2)",
+        params![id, embedding.as_bytes()],
+    )?;
+    Ok(())
+}
+
+pub fn search_similar(conn: &Connection, query_embedding: &[f32], limit: usize) -> SqliteResult<Vec<(String, f32)>> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT docs.path, vec_distance_cosine(vec_docs.embedding, ?1) as distance
+        FROM vec_docs
+        JOIN docs ON docs.id = vec_docs.rowid
+        WHERE vec_docs.embedding MATCH ?1 AND k = ?2
+        ORDER BY distance
+        "
+    )?;
+    let results = stmt.query_map(
+        params![query_embedding.as_bytes(), limit as i64],
+        |row| {
+            let path: String = row.get(0)?;
+            let distance: f32 = row.get(1)?;
+            Ok((path, distance))
+        }
+    )?;
+    let mut matches = Vec::new();
+    for result in results {
+        matches.push(result?);
+    }
+    Ok(matches)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vec_insertion_and_search() {
+        let conn = Connection::open_in_memory().unwrap();
+        unsafe { sqlite3_vec_init(conn.handle()) };
+        
+        conn.execute_batch(
+            "
+            CREATE TABLE docs(id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT UNIQUE);
+            CREATE VIRTUAL TABLE vec_docs USING vec0(embedding float[3]);
+            "
+        ).unwrap();
+
+        let path1 = PathBuf::from("doc1.md");
+        let path2 = PathBuf::from("doc2.md");
+        let vec1 = vec![1.0, 0.0, 0.0];
+        let vec2 = vec![0.0, 1.0, 0.0];
+
+        upsert_embedding(&conn, &path1, &vec1).unwrap();
+        upsert_embedding(&conn, &path2, &vec2).unwrap();
+
+        let query = vec![1.0, 0.1, 0.0];
+        let results = search_similar(&conn, &query, 1).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "doc1.md");
+    }
+}

--- a/src-tauri/src/core/db.rs
+++ b/src-tauri/src/core/db.rs
@@ -1,16 +1,16 @@
-use rusqlite::{params, Connection, Result as SqliteResult};
+use rusqlite::{ffi::sqlite3_auto_extension, params, Connection, Result as SqliteResult};
 use sqlite_vec::sqlite3_vec_init;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zerocopy::IntoBytes;
 
 
 pub fn init_db(vault_path: &Path) -> SqliteResult<Connection> {
+    unsafe {
+        sqlite3_auto_extension(Some(std::mem::transmute(sqlite3_vec_init as *const ())));
+    }
     let db_path = vault_path.join(".cerebro.db");
     let db = Connection::open(&db_path)?;
     db.execute_batch("PRAGMA journal_mode = WAL;")?;
-    unsafe {
-        sqlite3_vec_init(db.handle());
-    }
     db.execute_batch(
         "
         BEGIN;
@@ -73,11 +73,14 @@ pub fn search_similar(conn: &Connection, query_embedding: &[f32], limit: usize) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_vec_insertion_and_search() {
+        unsafe { 
+            sqlite3_auto_extension(Some(std::mem::transmute(sqlite3_vec_init as *const ())));
+        }
         let conn = Connection::open_in_memory().unwrap();
-        unsafe { sqlite3_vec_init(conn.handle()) };
         
         conn.execute_batch(
             "

--- a/src-tauri/src/core/error.rs
+++ b/src-tauri/src/core/error.rs
@@ -1,0 +1,20 @@
+use serde::{ser::Serializer, Serialize};
+
+#[derive(thiserror::Error, Debug)]
+pub enum AppError {
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] rusqlite::Error),
+    #[error("Embedding error: {0}")]
+    EmbeddingError(String),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+impl Serialize for AppError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,4 +1,7 @@
 //! Core business logic and background tasks.
 
+pub mod db;
 pub mod embedding;
+pub mod error;
+pub mod search;
 pub mod watcher;

--- a/src-tauri/src/core/search.rs
+++ b/src-tauri/src/core/search.rs
@@ -1,0 +1,26 @@
+use fastembed::TextEmbedding;
+use rusqlite::Connection;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::core::error::AppError;
+
+pub async fn search_notes(
+    query: String,
+    limit: usize,
+    db: Arc<Mutex<Connection>>,
+    model: Arc<TextEmbedding>,
+) -> Result<Vec<(String, f32)>, AppError> {
+    let query_embedding = tokio::task::spawn_blocking(move || {
+        model.embed(vec![query], None)
+    })
+    .await
+    .map_err(|e| AppError::EmbeddingError(format!("Task spawn failed: {}", e)))?
+    .map_err(|e| AppError::EmbeddingError(format!("Embedding generation failed: {}", e)))?
+    .pop()
+    .ok_or_else(|| AppError::EmbeddingError("No embedding returned".to_string()))?;
+
+    let db_lock = db.lock().await;
+    let results = crate::core::db::search_similar(&db_lock, &query_embedding, limit)?;
+    Ok(results)
+}

--- a/src-tauri/src/core/watcher.rs
+++ b/src-tauri/src/core/watcher.rs
@@ -2,41 +2,50 @@
 
 use fastembed::TextEmbedding;
 use notify::{Event, EventKind, RecursiveMode, Watcher};
+use rusqlite::Connection;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
+use crate::core::error::AppError;
 
-/// Processes a single file to generate embeddings.
-pub async fn process_file(path: PathBuf, model: Arc<TextEmbedding>) -> Result<Vec<f32>, String> {
+pub async fn process_file(
+    path: PathBuf,
+    model: Arc<TextEmbedding>,
+    db: Arc<Mutex<Connection>>,
+) -> Result<(), AppError> {
     let start = std::time::Instant::now();
 
-    let contents = fs::read_to_string(&path)
-        .await
-        .map_err(|e| format!("Failed to read file: {}", e))?;
+    let contents = fs::read_to_string(&path).await?;
 
     let embeddings = tokio::task::spawn_blocking(move || model.embed(vec![contents], None))
         .await
-        .map_err(|e| format!("Task spawn failed: {}", e))?;
+        .map_err(|e| AppError::EmbeddingError(format!("Task spawn failed: {}", e)))?;
 
-    match embeddings {
-        Ok(mut e) => {
-            let elapsed = start.elapsed();
-            let embedding = e.pop().unwrap();
-            println!(
-                "Generated embedding for {:?} in {:?} | Size: {}",
-                path.file_name().unwrap_or_default(),
-                elapsed,
-                embedding.len()
-            );
-            Ok(embedding)
-        }
-        Err(err) => Err(format!("Error during embedding generation: {:?}", err)),
-    }
+    let embedding = match embeddings {
+        Ok(mut e) => e.pop().unwrap(),
+        Err(err) => return Err(AppError::EmbeddingError(format!("Error during embedding generation: {:?}", err))),
+    };
+
+    let db_lock = db.lock().await;
+    crate::core::db::upsert_embedding(&db_lock, &path, &embedding)?;
+
+    let elapsed = start.elapsed();
+    println!(
+        "Generated and saved embedding for {:?} in {:?}",
+        path.file_name().unwrap_or_default(),
+        elapsed
+    );
+
+    Ok(())
 }
 
 /// Starts a background directory watcher that generates embeddings when markdown files change.
-pub async fn start_watching(vault_path: PathBuf, model: Arc<TextEmbedding>) {
+pub async fn start_watching(
+    vault_path: PathBuf,
+    model: Arc<TextEmbedding>,
+    db: Arc<Mutex<Connection>>,
+) {
     let (tx, mut rx) = mpsc::channel(100);
 
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
@@ -54,10 +63,11 @@ pub async fn start_watching(vault_path: PathBuf, model: Arc<TextEmbedding>) {
             for path in event.paths {
                 if path.extension().and_then(|s| s.to_str()) == Some("md") {
                     let model_clone = Arc::clone(&model);
+                    let db_clone = Arc::clone(&db);
                     let path_clone = path.clone();
 
                     tokio::spawn(async move {
-                        if let Err(e) = process_file(path_clone, model_clone).await {
+                        if let Err(e) = process_file(path_clone, model_clone, db_clone).await {
                             eprintln!("Error processing file: {}", e);
                         }
                     });
@@ -77,8 +87,13 @@ mod tests {
     async fn test_process_file_generates_different_embeddings_for_different_files() {
         // 1. Initialize the embedding model
         let model = crate::core::embedding::init_model().await;
+        
+        // 2. Init in-memory db to pass into the process_file function
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = crate::core::db::init_db(temp_dir.path()).unwrap();
+        let db_arc = Arc::new(Mutex::new(db));
 
-        // 2. Create two temporary files with different textual contents
+        // 3. Create two temporary files with different textual contents
         let mut file1 = NamedTempFile::new().unwrap();
         writeln!(file1, "The core philosophy is Friction as a Feature.").unwrap();
         let path1 = file1.path().to_path_buf();
@@ -87,23 +102,18 @@ mod tests {
         writeln!(file2, "Synaptic Pruning handles automatic archival over 90 days.").unwrap();
         let path2 = file2.path().to_path_buf();
 
-        // 3. Process both files simulating the "on file save" scenario
-        let embedding1 = process_file(path1, Arc::clone(&model))
+        // 4. Process both files simulating the "on file save" scenario
+        process_file(path1, Arc::clone(&model), Arc::clone(&db_arc))
             .await
             .expect("Failed to process file 1");
 
-        let embedding2 = process_file(path2, Arc::clone(&model))
+        process_file(path2, Arc::clone(&model), Arc::clone(&db_arc))
             .await
             .expect("Failed to process file 2");
 
-        // 4. Validate they exist and have exactly the same dimension length (all-MiniLM-L6-v2 uses 384 dimensions)
-        assert_eq!(embedding1.len(), 384);
-        assert_eq!(embedding2.len(), 384);
-
-        // 5. Validation: Two different files should result in two different embeddings
-        assert_ne!(
-            embedding1, embedding2,
-            "Two different files must not have the identical embeddings"
-        );
+        // Validate that both entered the DB
+        let db_lock = db_arc.lock().await;
+        let count: i32 = db_lock.query_row("SELECT COUNT(*) FROM docs", rusqlite::params![], |row| row.get(0)).unwrap();
+        assert_eq!(count, 2);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,26 +1,57 @@
 //! Application library entry point where Tauri builder is configured.
 
+use tauri::{Manager, State};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use rusqlite::Connection;
+use fastembed::TextEmbedding;
+
 pub mod core;
 
-/// Sets up the Tauri application builder and runs the app.
+struct AppState {
+    db: Arc<Mutex<Connection>>,
+    model: Arc<TextEmbedding>,
+}
+
+#[tauri::command]
+async fn search_notes(
+    query: String,
+    limit: usize,
+    state: State<'_, AppState>,
+) -> Result<Vec<(String, f32)>, core::error::AppError> {
+    core::search::search_notes(query, limit, Arc::clone(&state.db), Arc::clone(&state.model)).await
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .setup(|_app| {
+        .setup(|app| {
             let vault_path = std::env::current_dir().unwrap().join("vault");
 
             if !vault_path.exists() {
                 std::fs::create_dir_all(&vault_path).unwrap();
             }
 
+            let db = core::db::init_db(&vault_path).expect("Failed to init DB");
+            let db_arc = Arc::new(Mutex::new(db));
+            
+            let handle = app.handle().clone();
+
             tauri::async_runtime::spawn(async move {
                 let model = crate::core::embedding::init_model().await;
-                crate::core::watcher::start_watching(vault_path, model).await;
+                
+                handle.manage(AppState {
+                    db: Arc::clone(&db_arc),
+                    model: Arc::clone(&model),
+                });
+                
+                crate::core::watcher::start_watching(vault_path, model, db_arc).await;
             });
 
             Ok(())
         })
         .plugin(tauri_plugin_opener::init())
+        .invoke_handler(tauri::generate_handler![search_notes])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
Resolves #5

## Changes Made
- Added `rusqlite` (bundled feature) and `sqlite-vec` dependencies.
- Created a new `core::db` module that initializes a local `.cerebro.db` SQLite database using the `vec0` virtual table.
- Upgraded the file watcher in `core::watcher` to automatically store generated embeddings into the database.
- Implemented `search_notes` Tauri command using cosine similarity (`vec_distance_cosine`) to return relevant markdown files.
- Refactored IPC to use `tauri::State` for dependency injection (DB pool and model) and added a standard `AppError` enum using `thiserror` for clean Rust error handling across the barrier.

All acceptance criteria from the original issue have been met. The source of truth remains the human-readable Markdown files.